### PR TITLE
Mise à jour des informations d'installation de react navigation

### DIFF
--- a/04.2-navigation/README.md
+++ b/04.2-navigation/README.md
@@ -9,6 +9,14 @@ Mettre en place une navigation avec react-navigation et utiliser les composants 
     ```bash
         npm install --save react-navigation
     ```
+3. Installer React Native Gesture Handlers
+    ```bash
+        npm install --save react-native-gesture-handler
+    ```
+4. Lier les modules React Native au code source natif
+    ```bash
+       react-native link
+    ```
 
 ## Instructions
 1. Créer un composant `SearchForm` (`src/containers/SearchForm.js`) affichant pour l'instant juste un texte de votre choix (ce composant sera enrichi lors du prochain TP).


### PR DESCRIPTION
Il faut installer le module `react-native-gesture-handler` et le lier avec la commande `link` pour que le projet compile.

Sinon, une erreur survient lors du lancement / hot reload de l'application.

Source: https://reactnavigation.org/docs/en/getting-started.html